### PR TITLE
Filter menu groups based on user access to child items

### DIFF
--- a/localgov_menu_link_group.module
+++ b/localgov_menu_link_group.module
@@ -14,18 +14,19 @@ use Drupal\Core\Menu\MenuTreeParameters;
 /**
  * Implements hook_preprocess_menu().
  */
-function localGov_menu_link_group_preprocess_menu(&$variables) {
+function localgov_menu_link_group_preprocess_menu(&$variables) {
   _localgov_menu_link_group_filter_menu($variables['items'], $variables['menu_name']);
 }
 
 /**
- * Filter menu
+ * Filter menu.
  *
  * Walk through the menu tree to find menu link groups, and remove any that
  * the current user does not have access to any child items.
- * @param  array $items
+ *
+ * @param array $items
  *   (By reference) Menu items tree passed from hook_preprocess_menu.
- * @param  string $menu_name
+ * @param string $menu_name
  *   Menu name.
  */
 function _localgov_menu_link_group_filter_menu(array &$items, string $menu_name) {
@@ -37,13 +38,13 @@ function _localgov_menu_link_group_filter_menu(array &$items, string $menu_name)
       // localgov_menu_group menu link in the 'below' array.
       $menu_tree_params = new MenuTreeParameters();
       $menu_tree_params->setRoot($item['original_link']->getPluginId())
-                       ->excludeRoot()
-                       ->setMaxDepth(1)
-                       ->onlyEnabledLinks();
+        ->excludeRoot()
+        ->setMaxDepth(1)
+        ->onlyEnabledLinks();
       $tree = \Drupal::menuTree()->load($menu_name, $menu_tree_params);
 
       // Test if the user has access to any menu items in this menu group.
-      $enabled = array_map(function($subtree_item) {
+      $enabled = array_map(function ($subtree_item) {
         $route_name = $subtree_item->link->getRouteName();
         $route_parameters = $subtree_item->link->getRouteParameters();
         return (bool) \Drupal::accessManager()->checkNamedRoute($route_name, $route_parameters);

--- a/localgov_menu_link_group.module
+++ b/localgov_menu_link_group.module
@@ -9,6 +9,58 @@ declare(strict_types = 1);
 
 use Drupal\localgov_menu_link_group\MenuLinkGrouper;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Menu\MenuTreeParameters;
+
+/**
+ * Implements hook_preprocess_menu().
+ */
+function localGov_menu_link_group_preprocess_menu(&$variables) {
+  _localgov_menu_link_group_filter_menu($variables['items'], $variables['menu_name']);
+}
+
+/**
+ * Filter menu
+ *
+ * Walk through the menu tree to find menu link groups, and remove any that
+ * the current user does not have access to any child items.
+ * @param  array $items
+ *   (By reference) Menu items tree passed from hook_preprocess_menu.
+ * @param  string $menu_name
+ *   Menu name.
+ */
+function _localgov_menu_link_group_filter_menu(array &$items, string $menu_name) {
+  foreach ($items as $route => &$item) {
+    if (strpos($route, 'localgov_menu_link_group') === 0) {
+
+      // Load up the menu tree from this point using the Menu tree service.
+      // Has to be done this was as the menu child items don't appear in a
+      // localgov_menu_group menu link in the 'below' array.
+      $menu_tree_params = new MenuTreeParameters();
+      $menu_tree_params->setRoot($item['original_link']->getPluginId())
+                       ->excludeRoot()
+                       ->setMaxDepth(1)
+                       ->onlyEnabledLinks();
+      $tree = \Drupal::menuTree()->load($menu_name, $menu_tree_params);
+
+      // Test if the user has access to any menu items in this menu group.
+      $enabled = array_map(function($subtree_item) {
+        $route_name = $subtree_item->link->getRouteName();
+        $route_parameters = $subtree_item->link->getRouteParameters();
+        return (bool) \Drupal::accessManager()->checkNamedRoute($route_name, $route_parameters);
+      }, $tree);
+
+      // If no access to child items, remove the menu group item in this menu.
+      if (!array_filter($enabled)) {
+        unset($items[$route]);
+      }
+    }
+
+    // If there are menu items below this, pass those through this function.
+    if (!empty($item['below'])) {
+      _localgov_menu_link_group_filter_menu($item['below'], $menu_name);
+    }
+  }
+}
 
 /**
  * Implements hook_menu_links_discovered_alter().

--- a/localgov_menu_link_group.module
+++ b/localgov_menu_link_group.module
@@ -15,6 +15,7 @@ use Drupal\Core\Menu\MenuTreeParameters;
  * Implements hook_preprocess_menu().
  */
 function localgov_menu_link_group_preprocess_menu(&$variables) {
+  $variables['menu_name'] = $variables['menu_name'] ?? 'admin';
   _localgov_menu_link_group_filter_menu($variables['items'], $variables['menu_name']);
 }
 

--- a/tests/src/Kernel/GroupAccessTest.php
+++ b/tests/src/Kernel/GroupAccessTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\Tests\localgov_menu_link_group\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Component\Utility\Html;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Menu link group access test.
+ *
+ * When a Menu link group has no children, it should not be rendered.
+ *
+ * @group localgov_menu_link_group
+ */
+class GroupAccessTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'user',
+    'toolbar',
+    'localgov_menu_link_group',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * Test that the "Test" group is present.
+   *
+   * - Users with the 'administer site configuration' permission should see this
+   *   Menu link group.
+   */
+  public function testGroupAccess() {
+
+    $this->container->get('module_installer')->install(['group_config_test']);
+
+    // Admin user should see the "Test" Menu link group.
+    $user_a = $this->createUser([
+      'access administration pages',
+      'access toolbar',
+      'administer site configuration',
+    ]);
+    $this->container->get('account_switcher')->switchTo($user_a);
+
+    $toolbar = toolbar_get_rendered_subtrees();
+    $rendered_config_menu_markup = (string) $toolbar[0]['system-admin_config'];
+    $dom = Html::load($rendered_config_menu_markup);
+    $xpath = new \DomXPath($dom);
+
+    $has_test_group = ($xpath->query('//span[text()="Test"]')->count() === 1);
+    $this->assertTrue($has_test_group);
+
+    // Non-admin user should not see the "Test" Menu link group.
+    $user_b = $this->createUser([
+      'access administration pages',
+      'access toolbar',
+    ]);
+    $this->container->get('account_switcher')->switchTo($user_b);
+
+    $toolbar = toolbar_get_rendered_subtrees();
+    $rendered_config_menu_markup = (string) $toolbar[0]['system-admin_config'];
+    $dom = Html::load($rendered_config_menu_markup);
+    $xpath = new \DomXPath($dom);
+
+    $has_test_group = ($xpath->query('//span[text()="Test"]')->count() === 1);
+    $this->assertFalse($has_test_group);
+  }
+
+}

--- a/tests/src/Kernel/GroupAccessTest.php
+++ b/tests/src/Kernel/GroupAccessTest.php
@@ -22,7 +22,7 @@ class GroupAccessTest extends KernelTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'toolbar',
@@ -32,7 +32,7 @@ class GroupAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installSchema('system', ['sequences']);


### PR DESCRIPTION
Fix #3
Use hook_preprocess_menu to filter out menu link groups where the current
user does not have access to the child items.