### PR TITLE
Release 1.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,21 @@ jobs:
           echo "GIT_BASE=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
-
+          
       - name: Save git branch and git repo names to env if this is a pull request
         if: github.event_name == 'pull_request'
         run: |
           echo "GIT_BASE=${GITHUB_BASE_REF}" >> $GITHUB_ENV
           echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+  
+      - name: Set composer branch reference for version branches
+        if: endsWith(github.ref, '.x')
+        run: echo "COMPOSER_REF=${GIT_BRANCH}-dev" >> $GITHUB_ENV
+          
+      - name: Set composer branch reference for non-version branches
+        if: endsWith(github.ref, '.x') == false
+        run: echo "COMPOSER_REF=dev-${GIT_BRANCH}" >> $GITHUB_ENV
 
       - name: Cached workspace
         uses: actions/cache@v2
@@ -63,15 +71,15 @@ jobs:
           composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
           composer require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
           composer install
-
+          
       - name: Setup package source and authentication for the test target
         run: |
           composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as ${GIT_BASE%'.x'}"
-
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"${COMPOSER_REF} as ${GIT_BASE%'.x'}"
+        
   phpcs:
     name: Coding standards checks
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ name: Test LocalGov Drupal Menu Link Group module
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - '1.x'
   pull_request:
-    branches: [ master ]
+    branches:
+      - '1.x'
 
 jobs:
 
@@ -12,39 +14,55 @@ jobs:
     name: Install LocalGov Drupal
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
+          - localgov-version: "2.x"
+            drupal-version: "~9.1"
+            php-version: "7.4"
+
     steps:
-
-      - name: Cached workspace
-        uses: actions/cache@v2
-        with:
-          path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-
-      - name: Clone drupal_container
-        uses: actions/checkout@v2
-        with:
-          repository: localgovdrupal/drupal-container
-          ref: master
-
-      - name: Create LocalGov Drupal project
-        run: composer create-project --stability dev localgovdrupal/localgov-project ./html
 
       - name: Save git branch and git repo names to env if this is not a pull request
         if: github.event_name != 'pull_request'
         run: |
+          echo "GIT_BASE=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
 
       - name: Save git branch and git repo names to env if this is a pull request
         if: github.event_name == 'pull_request'
         run: |
+          echo "GIT_BASE=${GITHUB_BASE_REF}" >> $GITHUB_ENV
           echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+
+      - name: Cached workspace
+        uses: actions/cache@v2
+        with:
+          path: ./html
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Clone drupal_container
+        uses: actions/checkout@v2
+        with:
+          repository: localgovdrupal/drupal-container
+          ref: php${{ matrix.php-version }}
+
+      - name: Create LocalGov Drupal project
+        run: |
+          composer create-project --stability dev --no-install localgovdrupal/localgov-project ./html "${{ matrix.localgov-version }}"
+          composer require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
+          composer install
 
       - name: Setup package source and authentication for the test target
         run: |
@@ -52,12 +70,23 @@ jobs:
           composer global config github-oauth.github.com ${{ github.token }}
 
       - name: Obtain the test target from the repo that triggered this workflow
-        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
+        run: composer --working-dir=html require --with-all-dependencies localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as ${GIT_BASE%'.x'}"
 
   phpcs:
     name: Coding standards checks
     needs: build
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
+          - localgov-version: "2.x"
+            drupal-version: "~9.1"
+            php-version: "7.4"
 
     steps:
 
@@ -65,9 +94,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -84,15 +113,26 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
+          - localgov-version: "2.x"
+            drupal-version: "~9.1"
+            php-version: "7.4"
+
     steps:
 
       - name: Cached workspace
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -109,6 +149,17 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - localgov-version: "1.x"
+            drupal-version: "~8.9"
+            php-version: "7.4"
+          - localgov-version: "2.x"
+            drupal-version: "~9.1"
+            php-version: "7.4"
+
     steps:
 
       - name: Clone drupal_container
@@ -121,9 +172,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./html
-          key: ${{ runner.os }}-localgov-build-${{ github.run_id }}
+          key: localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-localgov-build-
+            localgov-build-${{ matrix.localgov-version }}-${{ matrix.drupal-version }}-${{ matrix.php-version }}-
 
       - name: Start Docker environment
         run: docker-compose -f docker-compose.yml up -d

--- a/localgov_menu_link_group.module
+++ b/localgov_menu_link_group.module
@@ -14,18 +14,19 @@ use Drupal\Core\Menu\MenuTreeParameters;
 /**
  * Implements hook_preprocess_menu().
  */
-function localGov_menu_link_group_preprocess_menu(&$variables) {
+function localgov_menu_link_group_preprocess_menu(&$variables) {
   _localgov_menu_link_group_filter_menu($variables['items'], $variables['menu_name']);
 }
 
 /**
- * Filter menu
+ * Filter menu.
  *
  * Walk through the menu tree to find menu link groups, and remove any that
  * the current user does not have access to any child items.
- * @param  array $items
+ *
+ * @param array $items
  *   (By reference) Menu items tree passed from hook_preprocess_menu.
- * @param  string $menu_name
+ * @param string $menu_name
  *   Menu name.
  */
 function _localgov_menu_link_group_filter_menu(array &$items, string $menu_name) {
@@ -37,13 +38,13 @@ function _localgov_menu_link_group_filter_menu(array &$items, string $menu_name)
       // localgov_menu_group menu link in the 'below' array.
       $menu_tree_params = new MenuTreeParameters();
       $menu_tree_params->setRoot($item['original_link']->getPluginId())
-                       ->excludeRoot()
-                       ->setMaxDepth(1)
-                       ->onlyEnabledLinks();
+        ->excludeRoot()
+        ->setMaxDepth(1)
+        ->onlyEnabledLinks();
       $tree = \Drupal::menuTree()->load($menu_name, $menu_tree_params);
 
       // Test if the user has access to any menu items in this menu group.
-      $enabled = array_map(function($subtree_item) {
+      $enabled = array_map(function ($subtree_item) {
         $route_name = $subtree_item->link->getRouteName();
         $route_parameters = $subtree_item->link->getRouteParameters();
         return (bool) \Drupal::accessManager()->checkNamedRoute($route_name, $route_parameters);

--- a/localgov_menu_link_group.module
+++ b/localgov_menu_link_group.module
@@ -9,6 +9,58 @@ declare(strict_types = 1);
 
 use Drupal\localgov_menu_link_group\MenuLinkGrouper;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Menu\MenuTreeParameters;
+
+/**
+ * Implements hook_preprocess_menu().
+ */
+function localGov_menu_link_group_preprocess_menu(&$variables) {
+  _localgov_menu_link_group_filter_menu($variables['items'], $variables['menu_name']);
+}
+
+/**
+ * Filter menu
+ *
+ * Walk through the menu tree to find menu link groups, and remove any that
+ * the current user does not have access to any child items.
+ * @param  array $items
+ *   (By reference) Menu items tree passed from hook_preprocess_menu.
+ * @param  string $menu_name
+ *   Menu name.
+ */
+function _localgov_menu_link_group_filter_menu(array &$items, string $menu_name) {
+  foreach ($items as $route => &$item) {
+    if (strpos($route, 'localgov_menu_link_group') === 0) {
+
+      // Load up the menu tree from this point using the Menu tree service.
+      // Has to be done this was as the menu child items don't appear in a
+      // localgov_menu_group menu link in the 'below' array.
+      $menu_tree_params = new MenuTreeParameters();
+      $menu_tree_params->setRoot($item['original_link']->getPluginId())
+                       ->excludeRoot()
+                       ->setMaxDepth(1)
+                       ->onlyEnabledLinks();
+      $tree = \Drupal::menuTree()->load($menu_name, $menu_tree_params);
+
+      // Test if the user has access to any menu items in this menu group.
+      $enabled = array_map(function($subtree_item) {
+        $route_name = $subtree_item->link->getRouteName();
+        $route_parameters = $subtree_item->link->getRouteParameters();
+        return (bool) \Drupal::accessManager()->checkNamedRoute($route_name, $route_parameters);
+      }, $tree);
+
+      // If no access to child items, remove the menu group item in this menu.
+      if (!array_filter($enabled)) {
+        unset($items[$route]);
+      }
+    }
+
+    // If there are menu items below this, pass those through this function.
+    if (!empty($item['below'])) {
+      _localgov_menu_link_group_filter_menu($item['below'], $menu_name);
+    }
+  }
+}
 
 /**
  * Implements hook_menu_links_discovered_alter().

--- a/localgov_menu_link_group.module
+++ b/localgov_menu_link_group.module
@@ -15,6 +15,7 @@ use Drupal\Core\Menu\MenuTreeParameters;
  * Implements hook_preprocess_menu().
  */
 function localgov_menu_link_group_preprocess_menu(&$variables) {
+  $variables['menu_name'] = $variables['menu_name'] ?? 'admin';
   _localgov_menu_link_group_filter_menu($variables['items'], $variables['menu_name']);
 }
 

--- a/tests/src/Kernel/GroupAccessTest.php
+++ b/tests/src/Kernel/GroupAccessTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\Tests\localgov_menu_link_group\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Component\Utility\Html;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Menu link group access test.
+ *
+ * When a Menu link group has no children, it should not be rendered.
+ *
+ * @group localgov_menu_link_group
+ */
+class GroupAccessTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'system',
+    'user',
+    'toolbar',
+    'localgov_menu_link_group',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * Test that the "Test" group is present.
+   *
+   * - Users with the 'administer site configuration' permission should see this
+   *   Menu link group.
+   */
+  public function testGroupAccess() {
+
+    $this->container->get('module_installer')->install(['group_config_test']);
+
+    // Admin user should see the "Test" Menu link group.
+    $user_a = $this->createUser([
+      'access administration pages',
+      'access toolbar',
+      'administer site configuration',
+    ]);
+    $this->container->get('account_switcher')->switchTo($user_a);
+
+    $toolbar = toolbar_get_rendered_subtrees();
+    $rendered_config_menu_markup = (string) $toolbar[0]['system-admin_config'];
+    $dom = Html::load($rendered_config_menu_markup);
+    $xpath = new \DomXPath($dom);
+
+    $has_test_group = ($xpath->query('//span[text()="Test"]')->count() === 1);
+    $this->assertTrue($has_test_group);
+
+    // Non-admin user should not see the "Test" Menu link group.
+    $user_b = $this->createUser([
+      'access administration pages',
+      'access toolbar',
+    ]);
+    $this->container->get('account_switcher')->switchTo($user_b);
+
+    $toolbar = toolbar_get_rendered_subtrees();
+    $rendered_config_menu_markup = (string) $toolbar[0]['system-admin_config'];
+    $dom = Html::load($rendered_config_menu_markup);
+    $xpath = new \DomXPath($dom);
+
+    $has_test_group = ($xpath->query('//span[text()="Test"]')->count() === 1);
+    $this->assertFalse($has_test_group);
+  }
+
+}

--- a/tests/src/Kernel/GroupAccessTest.php
+++ b/tests/src/Kernel/GroupAccessTest.php
@@ -22,7 +22,7 @@ class GroupAccessTest extends KernelTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'toolbar',
@@ -32,7 +32,7 @@ class GroupAccessTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installSchema('system', ['sequences']);


### PR DESCRIPTION
This contains the bug fix for filtering menu link groups that a user does not have permission for any child items.

Commits on Feb 14, 2021
@andybroomfield
Filter menu groups based on user access to child items …
d48b71f
Commits on Apr 02, 2021
@andybroomfield
Fix the hook name
fb2512a
Commits on May 14, 2021
@Adnan-cds
Tests for Menu link group access. …
72352ab
Commits on May 18, 2021
@stephen-cox
Updated GitHub CI to test the 1.x branch against D8 and D9
a1359e4
Commits on May 19, 2021
@stephen-cox
Update GitHub Actions to check branch versions
122fc6c
@stephen-cox
Updated GitHub CI to test the 1.x branch against D8 and D9 (#12)
7b56580
Commits on May 26, 2021
@stephen-cox
Merge branch '1.x' into fix/3-filter-based-on-access
7abad86
@stephen-cox
Fixed D9 code deprecations warnings
2beaf39
@Adnan-cds
Merge pull request #5 from localgovdrupal/fix/3-filter-based-on-access …
a97a6dc