### PR TITLE
fix: add missing D11 requirement for test module

### DIFF
--- a/tests/modules/group_config_test/group_config_test.info.yml
+++ b/tests/modules/group_config_test/group_config_test.info.yml
@@ -2,4 +2,4 @@ name: 'Group config test'
 description: 'Configuration import test module for the localgov_menu_link_group config entity.'
 type: module
 package: Testing
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Adds a missing requirement bump